### PR TITLE
Responsive layout for smaller screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
       gtag('config', 'UA-37862592-3');
     </script>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Crafting reference for One Hour One Life</title>
   </head>
   <body>

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,11 +6,11 @@
 
     <div v-if="gameData">
       <ObjectSearch :objects="nonNilObjects" :selectedObject="selectedObject" />
-      
+
       <div v-if="selectedObject">
         <ObjectInspector :object="selectedObject" />
       </div>
-      
+
       <div v-if="!selectedObject">
         <div class="objectList">
           <div class="object" v-for="object in firstFewObjects" >
@@ -62,7 +62,7 @@ export default {
     objectFromUrl () {
       if (!this.gameData) return;
       if (!window.location.hash) {
-        this.selectedObject = null;  
+        this.selectedObject = null;
       } else {
         let objid = window.location.hash.split('#')[1].split('/')[0];
         this.selectedObject = this.gameData.objectMap[objid];
@@ -93,6 +93,7 @@ export default {
         window.location.hash = '#';
       }
       vue.showAmount = 90;
+      document.body.scrollTop = document.documentElement.scrollTop = 0;
     });
 
     window.onhashchange = () => vue.objectFromUrl();
@@ -106,10 +107,11 @@ export default {
 </script>
 
 <style lang="scss">
-  body { 
+  body {
     background-color: #151515;
     margin: 0 auto;
-    width: 1024px;
+    padding: 0 20px;
+    max-width: 1024px;
     padding-left: calc(100vw - 100%);
   }
 
@@ -138,6 +140,15 @@ export default {
   }
 
   .object {
+    min-width: 200px;
+    width: 33.3333%;
+  }
+
+  @media only screen and (max-width: 768px) {
+    .object {
+      min-width: 150px;
+      width: 50%;
+    }
   }
 
   .objectList {

--- a/src/components/ObjectInspector.vue
+++ b/src/components/ObjectInspector.vue
@@ -42,8 +42,6 @@ export default {
 
 <style scoped>
   .objectInspector {
-    width: 100%;
-
     display: flex;
     flex-direction: column;
     align-content: center;
@@ -59,6 +57,7 @@ export default {
 
   .info {
     flex: 1 1 0;
+    min-width: 220px;
 
     background-color: #333;
     margin: 10px;
@@ -104,5 +103,18 @@ export default {
     display: flex;
     flex-direction: row;
     justify-content: center;
+  }
+
+  @media only screen and (max-width: 768px) {
+    .panels {
+      flex-direction: column;
+    }
+    .panels .transitions {
+      width: 100%;
+    }
+
+    .info {
+      order: -1;
+    }
   }
 </style>

--- a/src/components/ObjectView.vue
+++ b/src/components/ObjectView.vue
@@ -25,7 +25,6 @@ export default {
 
 <style scoped>
   .objectView {
-    width: 300px;
     height: 200px;
 
     display: flex;
@@ -46,5 +45,4 @@ export default {
   .objectView h3 {
     text-align: center;
   }
-
 </style>


### PR DESCRIPTION
This makes the site more convenient to use on small screens:
* Adds the viewport meta tag for better scale on phones
* Scrolls to the top of the page when selecting an object
* Changes body `width` to `max-width` so it scales dynamically with window width
* Places object info box at the top for small screens

**Note:** I didn't run the build command for this.

<img width="416" alt="screen shot 2018-03-12 at 10 07 51 am" src="https://user-images.githubusercontent.com/161/37298687-3331fca6-25de-11e8-8f2c-e083d8ec2641.png">

<img width="416" alt="screen shot 2018-03-12 at 10 07 30 am" src="https://user-images.githubusercontent.com/161/37298689-356fa608-25de-11e8-8060-3395b2f6c8e8.png">
