### PR TITLE
Use selected object for initial search value

### DIFF
--- a/src/components/ObjectSearch.vue
+++ b/src/components/ObjectSearch.vue
@@ -20,7 +20,7 @@ export default {
   props: ['objects', 'selectedObject'],
   data () {
     return {
-      tmpSelect: null
+      tmpSelect: this.selectedObject
     };
   },
   watch: {


### PR DESCRIPTION
This sets the the search box value to the selected object so when linking to or reloading the page it is populated. This allows one to go back to the index by clicking the "x".

Closes #4 