### PR TITLE
Handle different EOL formats when loading data

### DIFF
--- a/process/src/Category.js
+++ b/process/src/Category.js
@@ -4,7 +4,7 @@ class Category {
   constructor(dataText) {
     this.objectIDs = [];
     this.objectWeights = [];
-    const lines = dataText.split('\n');
+    const lines = dataText.split(/[\r\n]+/);
     let headers = true;
     for (let line of lines) {
       if (headers) {


### PR DESCRIPTION
When cloning the data files with git the line endings can be changed depending on git autocrlf settings.
If there are any carriage returns the parsing fails, so we need to either avoid them or strip them.
This change, stripping the carriage returns in addition to the line feeds, is the simplest and has the
benefit of also handling any future situation where carriage returns are added to the source files.