### PR TITLE
Fix falsey value bug causing certain tinted objects to display colour…

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -54,3 +54,10 @@ This is a list of items and transitions to check to ensure everything is correct
 * [Hand Cart](https://onetech.info/484-Hand-Cart/recipe): 1 log, wooden disks
 * [Running Crude Car](https://onetech.info/2396-Running-Crude-Car/recipe): 5 yew branches
 * [Cistern](https://onetech.info/672-Cistern/recipe): 10 stones
+
+
+### Tinted sprites
+
+* [Glass Bottle](https://onetech.info/3338-Glass-Bottle): it should not be flat and white
+* [Smoldering Tinder](https://onetech.info/78-Smoldering-Tinder): orange centre, no white
+* [Burnt Launch Pad](https://onetech.info/4997-Burnt-Launch-Pad): burns should be black, not appearing as the original shrimp

--- a/process/src/SpriteProcessor.js
+++ b/process/src/SpriteProcessor.js
@@ -119,7 +119,7 @@ class SpriteProcessor {
   drawSpriteDirectly(sprite, context) {
     this.drawSpriteImage(sprite, context);
 
-    if (sprite.color.find(c => c < 1.0)) {
+    if (sprite.color.find(c => c < 1.0) !== undefined) {
       this.overlayColor(sprite, context)
     }
   }


### PR DESCRIPTION
We were finding some objects not looking quite right in our fork for Two Hours One Life. I found that when a sprite has its tint/colour modified in the editor, the colouring would not be displayed in some cases. For example, we have one clothing type which has several variants. Default, red, blue and black had no issue, but green showed grey.

In the data for the object, this colour modification is represented as:
`color=0.000000,0.521127,0.190835` for [this object](https://github.com/twohoursonelife/OneLifeData7/blob/master/objects/14730.txt). But it could just as easily be `1.000000,0.000000,0.190835` or `1.000000,1.0000000.000000` and be susceptible.

Eventually it was narrowed down to this part where the value 0 was being interpreted as false. It would apply whenever any of the 3 values were equal to 0 and any of the preceding values were 1.

As far as I can tell, this has always been a problem. This change (unexpectedly) had an effect on processing of approximately 1,600 sprites for 2HOL.

Our issue tracking this: https://github.com/twohoursonelife/twotech/issues/42

This doesn't perfect transparency, but it helps with the effect. See https://github.com/twohoursonelife/twotech/issues/43

Before:
![image](https://github.com/Kazetsukai/onetech/assets/20902771/ba6bec51-d40b-443f-ae60-d355b4a884c5)
![image](https://github.com/Kazetsukai/onetech/assets/20902771/40e1e89e-9496-42eb-aaab-aded2a88745a)
![image](https://github.com/Kazetsukai/onetech/assets/20902771/b5182090-2920-4a6c-bf88-78b681e5c5f8)

After:
![image](https://github.com/Kazetsukai/onetech/assets/20902771/073ca0de-eed1-4a2f-a527-cf9410324036)
![image](https://github.com/Kazetsukai/onetech/assets/20902771/a628be7a-bd96-4abd-ab8d-e6bb9819cd66)
![image](https://github.com/Kazetsukai/onetech/assets/20902771/54111bc2-4dd1-4f9b-879d-15fe6682cfe8)
